### PR TITLE
Add Pico bridging docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
     "kalico_core",
     "ffi_py",
-    "service", "pico_bridge/pico_uart_bridge"]
+    "service",
+    "pico_bridge/pico_uart_bridge"]
 resolver = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,5 @@
 members = [
     "kalico_core",
     "ffi_py",
-    "service"
-]
+    "service", "pico_bridge/pico_uart_bridge"]
 resolver = "3"

--- a/docs/hardware_setup.md
+++ b/docs/hardware_setup.md
@@ -1,0 +1,14 @@
+# Hardware Setup
+
+This project communicates with external devices over a UART interface. If your
+host machine lacks a serial port you can repurpose a Raspberry Pi Pico as a
+USB-to-UART bridge. Two firmware options are provided:
+
+* **MicroPython**: `uart_bridge.py` – quick to flash and use.
+* **Rust**: `pico_uart_bridge/` – built with the `rp-pico` crate for a fully
+  native implementation.
+
+Both reside in [`pico_bridge/`](../pico_bridge). Follow the README there to
+flash either implementation. Once running, connect the device's TX/RX pins to
+the Pico's UART0 pins (GP0 and GP1) and use the USB connection to talk to the
+target device.

--- a/pico_bridge/README.md
+++ b/pico_bridge/README.md
@@ -1,0 +1,49 @@
+# Pico USB-to-UART Bridge
+
+This folder contains example firmware for turning a Raspberry Pi Pico into a
+USB-to-UART adapter. Two implementations are provided:
+
+* `uart_bridge.py` &ndash; a MicroPython script that forwards data between the
+  USB CDC interface and UART0.
+* `pico_uart_bridge/` &ndash; a Rust program using the `rp-pico` board support
+  crate. It runs USB and UART handling in interrupts for smooth throughput.
+
+Both allow you to connect a device's UART output to a host PC via the Pico's USB
+port.
+
+## Flashing Instructions
+
+1. Install MicroPython on the Pico using the official instructions from
+   [raspberrypi.com](https://www.raspberrypi.com/documentation/microcontrollers/micropython.html).
+2. Install `mpremote` from PyPI: `pip install mpremote`.
+3. Connect the Pico via USB while holding the BOOTSEL button and copy the
+   `uart_bridge.py` script as `main.py`:
+
+   ```bash
+   mpremote connect <port> fs cp uart_bridge.py :main.py
+   ```
+
+Replace `<port>` with the serial port of your board (for example `/dev/ttyACM0`).
+After reset, the Pico will forward traffic between the USB serial connection and
+its UART0 pins (GP0/GP1).
+
+### Rust firmware
+
+1. Install the `thumbv6m-none-eabi` target: `rustup target add thumbv6m-none-eabi`.
+2. Build the firmware:
+
+   ```bash
+   cargo build --release \
+     --manifest-path pico_bridge/pico_uart_bridge/Cargo.toml \
+     --target thumbv6m-none-eabi
+   ```
+
+3. Convert the resulting ELF to a UF2 file and flash it:
+
+   ```bash
+   elf2uf2-rs target/thumbv6m-none-eabi/release/pico_uart_bridge pico_uart_bridge.uf2
+   cp pico_uart_bridge.uf2 /media/$USER/RPI-RP2/
+   ```
+
+The Rust firmware behaves the same as the MicroPython version, forwarding bytes
+between USB and UART0.

--- a/pico_bridge/pico_uart_bridge/Cargo.toml
+++ b/pico_bridge/pico_uart_bridge/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pico_uart_bridge"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rp-pico = { version = "0.9", features = ["rt", "critical-section-impl"] }
+usb-device = "0.3"
+usbd-serial = "0.2"
+fugit = "0.3"
+panic-halt = "0.2"
+heapless = "0.8"

--- a/pico_bridge/pico_uart_bridge/src/main.rs
+++ b/pico_bridge/pico_uart_bridge/src/main.rs
@@ -1,0 +1,174 @@
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+use critical_section::Mutex;
+use fugit::RateExtU32;
+use heapless::spsc::Queue;
+use panic_halt as _;
+use rp_pico::entry;
+use rp_pico::hal::{self as hal, pac, Clock};
+use usb_device::{class_prelude::*, prelude::*};
+use usbd_serial::SerialPort;
+
+// Types for UART peripheral
+use hal::gpio::bank0::{Gpio0, Gpio1};
+use hal::gpio::{FunctionUart, Pin, PullNone};
+
+// Aliases to keep things tidy
+type UartPins = (
+    Pin<Gpio0, FunctionUart, PullNone>,
+    Pin<Gpio1, FunctionUart, PullNone>,
+);
+type Uart = hal::uart::UartPeripheral<hal::uart::Enabled, pac::UART0, UartPins>;
+
+static USB_BUS: Mutex<RefCell<Option<UsbBusAllocator<hal::usb::UsbBus>>>> =
+    Mutex::new(RefCell::new(None));
+static USB_DEVICE: Mutex<RefCell<Option<UsbDevice<hal::usb::UsbBus>>>> =
+    Mutex::new(RefCell::new(None));
+static USB_SERIAL: Mutex<RefCell<Option<SerialPort<hal::usb::UsbBus>>>> =
+    Mutex::new(RefCell::new(None));
+static UART: Mutex<RefCell<Option<Uart>>> = Mutex::new(RefCell::new(None));
+
+// Queues for moving bytes between USB and UART
+static mut USB_TO_UART: Queue<u8, 256> = Queue::new();
+static mut UART_TO_USB: Queue<u8, 256> = Queue::new();
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+    let clocks = hal::clocks::init_clocks_and_plls(
+        rp_pico::XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let sio = hal::Sio::new(pac.SIO);
+    let pins = rp_pico::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    let uart_pins = (
+        pins.gpio0.into_function::<FunctionUart>(),
+        pins.gpio1.into_function::<FunctionUart>(),
+    );
+
+    let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
+        .enable(
+            hal::uart::UartConfig::new(115_200u32.Hz(), hal::uart::DataBits::Eight, None, hal::uart::StopBits::One),
+            clocks.peripheral_clock.freq(),
+        )
+        .unwrap();
+
+    uart.enable_rx_interrupt();
+    uart.enable_tx_interrupt();
+
+    let usb_bus = UsbBusAllocator::new(hal::usb::UsbBus::new(
+        pac.USBCTRL_REGS,
+        pac.USBCTRL_DPRAM,
+        clocks.usb_clock,
+        true,
+        &mut pac.RESETS,
+    ));
+
+    critical_section::with(|cs| {
+        USB_BUS.borrow(cs).replace(Some(usb_bus));
+    });
+
+    let bus_ref = critical_section::with(|cs| USB_BUS.borrow(cs).as_ref().unwrap().clone());
+
+    let serial = SerialPort::new(&bus_ref);
+    critical_section::with(|cs| {
+        USB_SERIAL.borrow(cs).replace(Some(serial));
+    });
+
+    let strings = [
+        StringDescriptors::default()
+            .manufacturer("kalico")
+            .product("Pico UART Bridge")
+            .serial_number("0001"),
+    ];
+
+    let usb_dev = UsbDeviceBuilder::new(&bus_ref, UsbVidPid(0x1209, 0x0001))
+        .strings(&strings)
+        .unwrap()
+        .device_class(usbd_serial::USB_CLASS_CDC)
+        .build();
+
+    critical_section::with(|cs| {
+        USB_DEVICE.borrow(cs).replace(Some(usb_dev));
+        UART.borrow(cs).replace(Some(uart));
+    });
+
+    unsafe {
+        pac::NVIC::unmask(pac::Interrupt::USBCTRL_IRQ);
+        pac::NVIC::unmask(pac::Interrupt::UART0_IRQ);
+    }
+
+    // Main loop sleeps; all work happens in interrupts
+    loop {
+        cortex_m::asm::wfe();
+    }
+}
+
+#[allow(non_snake_case)]
+#[interrupt]
+unsafe fn USBCTRL_IRQ() {
+    critical_section::with(|cs| {
+        let dev_ref = USB_DEVICE.borrow(cs).as_mut().unwrap();
+        let serial_ref = USB_SERIAL.borrow(cs).as_mut().unwrap();
+
+        if dev_ref.poll(&mut [serial_ref]) {
+            let mut buf = [0u8; 64];
+            if let Ok(count) = serial_ref.read(&mut buf) {
+                if count > 0 {
+                    for &b in &buf[..count] {
+                        if let Some(q) = USB_TO_UART.enqueue(b).ok() {
+                            let _ = q; // suppress unused warning
+                        }
+                    }
+                }
+            }
+
+            while let Some(b) = unsafe { UART_TO_USB.dequeue() } {
+                let _ = serial_ref.write(&[b]);
+            }
+        }
+    });
+    cortex_m::asm::sev();
+}
+
+#[allow(non_snake_case)]
+#[interrupt]
+unsafe fn UART0_IRQ() {
+    critical_section::with(|cs| {
+        if let Some(uart) = UART.borrow(cs).as_mut() {
+            while let Ok(b) = uart.read() {
+                if let Some(q) = UART_TO_USB.enqueue(b).ok() {
+                    let _ = q;
+                }
+            }
+
+            while let Some(b) = unsafe { USB_TO_UART.dequeue() } {
+                if uart.write(b).is_err() {
+                    USB_TO_UART.enqueue(b).ok();
+                    break;
+                }
+            }
+        }
+    });
+    cortex_m::asm::sev();
+}
+

--- a/pico_bridge/pico_uart_bridge/src/main.rs
+++ b/pico_bridge/pico_uart_bridge/src/main.rs
@@ -135,9 +135,7 @@ unsafe fn USBCTRL_IRQ() {
             if let Ok(count) = serial_ref.read(&mut buf) {
                 if count > 0 {
                     for &b in &buf[..count] {
-                        if let Some(q) = USB_TO_UART.enqueue(b).ok() {
-                            let _ = q; // suppress unused warning
-                        }
+                        USB_TO_UART.enqueue(b).ok();
                     }
                 }
             }

--- a/pico_bridge/uart_bridge.py
+++ b/pico_bridge/uart_bridge.py
@@ -1,0 +1,12 @@
+import time
+from machine import UART, USB_VCP
+
+usb = USB_VCP()
+uart = UART(0, 115200)
+
+while True:
+    if usb.any():
+        uart.write(usb.read(usb.any()))
+    if uart.any():
+        usb.write(uart.read(uart.any()))
+    time.sleep_ms(1)

--- a/pico_bridge/uart_bridge.py
+++ b/pico_bridge/uart_bridge.py
@@ -5,8 +5,9 @@ usb = USB_VCP()
 uart = UART(0, 115200)
 
 while True:
-    if usb.any():
-        uart.write(usb.read(usb.any()))
+    usb_data_available = usb.any()
+    if usb_data_available:
+        uart.write(usb.read(usb_data_available))
     if uart.any():
         usb.write(uart.read(uart.any()))
     time.sleep_ms(1)


### PR DESCRIPTION
## Summary
- add MicroPython USB-UART bridge example for the Pico
- document how to flash the bridge with `mpremote`
- mention the bridge in new `docs/hardware_setup.md`
- add interrupt-based Rust bridge using rp-pico

## Testing
- `cargo test --all` *(fails: multiple `quarter` methods in `arrow-arith`)*
- `cargo check --workspace` *(fails: multiple `quarter` methods in `arrow-arith`)*

------
https://chatgpt.com/codex/tasks/task_e_685ce5b41f408321a58a61217399c48f